### PR TITLE
Implement TideTeraExt for Arc<RwLock<Tera>>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 repository = "https://github.com/jbr/tide-tera"
 
 [dependencies]
+async-std = { version = "1.9.0" }
 tide = { version = "0.16.0", default-features = false }
 tera = "1.6.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! [`Context`](tera::Context)s.
 
 use std::path::PathBuf;
+use async_std::{sync::{Arc, RwLock}, task};
 use tera::{Context, Tera};
 use tide::{http::Mime, Body, Response, Result};
 
@@ -61,6 +62,18 @@ impl TideTeraExt for Tera {
         let mut response = Response::new(200);
         response.set_body(self.render_body(template_name, context)?);
         Ok(response)
+    }
+}
+
+impl TideTeraExt for Arc<RwLock<Tera>> {
+    fn render_body(&self, template_name: &str, context: &Context) -> Result<Body> {
+        let tera = task::block_on(self.read());
+        tera.render_body(template_name, context)
+    }
+
+    fn render_response(&self, template_name: &str, context: &tera::Context) -> Result {
+        let tera = task::block_on(self.read());
+        tera.render_response(template_name, context)
     }
 }
 


### PR DESCRIPTION
This allows sharing the Tera instance across sync boundaries.

I have not run benchmarks, but the only time reading the Tera object will block is while templates are being reloaded, so any speed reduction should be minimal and will only be paid by people using the feature.

This PR does make async-std a dependency -- since Tide requires it I'm assuming that's acceptable, though this PR could easily be placed behind a feature flag.

My use case is hot-reloading templates with [notify](https://crates.io/crates/notify):

```rust
async fn main() -> anyhow::Result<()> {
    let mut templates = match Tera::new("views/**/*.html")?;
    templates.register_filter("filter_name", filter_function); // etc

    let templates = Arc::new(RwLock::new(templates));

    let mut app = tide::with_state(templates.clone());

    AuthenticationService::with_state(templates.clone())
        .at("/")
        .register(&mut app);
    UserProfileService::with_state(templates.clone())
        .at("/profile")
        .register(&mut app);

    let mut template_watcher =
        RecommendedWatcher::new(move |result: Result<Event, Error>| {
            let event = result.unwrap();
            if event.kind.is_modify() {
                let mut templ = task::block_on(templates.write());
                if let Err(e) = templ.full_reload() {
                    log::error!("Error reloading template: {:?}", e);
                }
            }
        });

    template_watcher.watch(Path::new("views"), RecursiveMode::Recursive)?;

    app.listen("localhost:8080").await?;
    Ok(())
}
```